### PR TITLE
Fix dynamic object name in release artifact

### DIFF
--- a/.ldrelease/linux-publish.sh
+++ b/.ldrelease/linux-publish.sh
@@ -1,5 +1,5 @@
 mkdir -p artifacts
 
 cp build/libldserverapi.a artifacts/${LD_LIBRARY_FILE_PREFIX}-libldserverapi.a
-cp build/libldserverapidynamic.so artifacts/${LD_LIBRARY_FILE_PREFIX}-libldserverapi.so
+cp build/libldserverapidynamic.so artifacts/${LD_LIBRARY_FILE_PREFIX}-libldserverapidynamic.so
 cp build/stores/redis/libldserverapi-redis.a artifacts/${LD_LIBRARY_FILE_PREFIX}-libldserverapi-redis.a


### PR DESCRIPTION
Otherwise, when the linker tries to load the object in runtime you get an error like this if you don't rename the file manually:

```
 - libldserverapidynamic.so: cannot open shared object file: No such file or directory
```
**Describe the solution you've provided**

It's better if users don't have to manually rename release artifacts.

**Describe alternatives you've considered**

I have to manually modify the artifact's name.
