### PR TITLE
Avoid "busy sleeping".

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -16,4 +16,9 @@ struct LDClient {
     bool shouldFlush;
     struct LDStore *store;
     struct EventProcessor *eventProcessor;
+    bool inClientInit;
+
+    ld_mutex_t threadSleepLock;
+    ld_cond_t threadSleepCond;
+    bool threadAwaken;
 };

--- a/src/network.h
+++ b/src/network.h
@@ -42,3 +42,6 @@ bool LDi_addHandle(CURLM *const multi,
     struct NetworkInterface *const networkInterface, CURL *const handle);
 
 bool LDi_removeAndFreeHandle(CURLM *const multi, CURL *const handle);
+
+bool LDi_interruptableSleep(struct LDClient *const client,
+    const unsigned long milliseconds);


### PR DESCRIPTION
Looping ~100x a second was sufficient to create a perceptible impact.

**Requirements**

- [x] I have added test coverage for new or changed functionality (_Covered by existing tests to extent possible IMO_)
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions (_I have no Mac_)

**Related issues**


**Describe the solution you've provided**

When there are large numbers of processes using c-server-sdk the network thread can be prominent in CPU profiling, ironically most often when it is providing the least value, ie there are no updates coming in.

This change replaces the use of `LDi_sleepMilliseconds` in the network thread with a wait on a condvar that can timeout, as well as be signaled. This allows the wait to be longer in duration, reducing CPU usage. `LDClientFlush`/`LDClientClose` have been modified to signal the condition to wake this wait up. We gradually ramp up the duration of the wait if there is no activity.

To preserve responsiveness when we are calling `LDClientInit` we track when we are in that function and keep the interval to the current 10ms. A better solution would be if `LDStoreInitialized` itself supported a timeout, but this would require some interface changes for LDStoreInterface.

**Describe alternatives you've considered**

* pipe or socketpair in conjuction with the `curl_multi_wait` call, moving the sleeping to that function. Unfortunately Windows SOCKETs are distinct from HANDLEs you might get from CreatePipe and there is no direct support for `socketpair`. Relatively recently Windows did get AF_UNIX socket support. Conversely MacOS does have socketpair, but I do not think it supports abstract or autobound unix sockets otherwise, which would mean the code would diverge between the platforms.
* Switch to `curl_multi_poll` and use `curl_multi_wakeup` from Flush/Close etc.  This is probably the ideal solution while continuing to take advantage of curl, but it implies a different minimum version of curl that what you can currently use.
* A simple knob to control the duration of the sleep. I have implemented something like this in a private fork but it doesn't solve the `LDClientInit` shouldn't wait around if it doesn't have to problem (something I ran into), and baking it into the interface makes it awkward later if a different better solution is implemented.
* Expose a pluggable interface for the analytics functionality, and allow LDClient to operate in a "threadless" mode. Like the custom store support, some kind of interface for implementing analytics could be provided (not unprecedented, see eg the go sdk), and folks could completely decouple from curl altogether. I don't think I am in a position to successfully design/implement a sweeping change like that in a PR though ;).
**Additional context**

Add any other context about the pull request here.
