### PR TITLE
Update PCRE download URL for Windows release

### DIFF
--- a/.ldrelease/build.ps1
+++ b/.ldrelease/build.ps1
@@ -39,7 +39,7 @@ If(Test-Path "pcre-8.43") {
     # NOTE: Recompute this SHA256 hash whenever the file is updated. This way we can detect
     # if the file has changed.
     $PcreSHA256 = "ae236dc25d7e0e738a94e103218e0085eb02ff9bd98f637b6e061a48decdb433"
-    $PcreURL = "https://iweb.dl.sourceforge.net/project/pcre/pcre/8.43/pcre-8.43.zip"
+    $PcreURL = "https://sourceforge.net/projects/pcre/files/pcre/8.43/pcre-8.43.zip/download"
 
     DownloadAndUnzip -url $PcreURL -filename "pcre.zip" -sha256 $PcreSHA256
 

--- a/.ldrelease/helpers.psm1
+++ b/.ldrelease/helpers.psm1
@@ -29,7 +29,7 @@ function DownloadAndUnzip {
         [Parameter(Mandatory)][string]$sha256
     )
     Write-Host Downloading and expanding $url
-    ExecuteOrFail { iwr -outf $filename $url }
+    ExecuteOrFail { iwr -UserAgent "NativeHost" -outf $filename $url }
     $Hash = Get-FileHash $filename -Algorithm SHA256
     if ($Hash.Hash -eq $sha256) {
         Write-Host "SHA256($filename) = ($($Hash.Hash)) OK"


### PR DESCRIPTION
Stop using a direct mirror link for the Windows PCRE dependency.

PCRE download succeeds: https://app.circleci.com/pipelines/github/launchdarkly/c-server-sdk/198/workflows/4711ee7b-7f7a-4042-beff-42ca4fe8f84c/jobs/594?invite=true#step-103-417
