### PR TITLE
releaser: increase Windows build timeout 

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       LD_LIBRARY_FILE_PREFIX: osx-clang-64bit
   - circleCI:
+      timeoutMinutes: 20 # Windows takes longer than usual to build & test.
       windows: {}  # the {} means "we want to specify windows here, but no special parameters within it"
     env:
       LD_LIBRARY_FILE_PREFIX: windows-vs-64bit


### PR DESCRIPTION
Testing a longer timeout for Windows releaser builds, as we are teetering on the edge of CircleCI's default 10 minute timeout (11 minutes, 48 seconds recently.)
- [x] Releaser dry-run success 