### PR TITLE
Fix strict prototypes warnings

### DIFF
--- a/c-sdk-common/src/ldvalue.c
+++ b/c-sdk-common/src/ldvalue.c
@@ -166,7 +166,7 @@ unsigned int LDValue_Count(struct LDValue *value) {
     return cJSON_GetArraySize(AS_CJSON(value));
 }
 
-struct LDObject *LDObject_New() {
+struct LDObject *LDObject_New(void) {
     return AS_LDOBJECT(cJSON_CreateObject());
 }
 

--- a/src/integrations/test_data.c
+++ b/src/integrations/test_data.c
@@ -96,7 +96,7 @@ LDBoolean LDi_isBooleanFlag(struct LDFlagBuilder *flagBuilder) {
 }
 
 struct LDTestData *
-LDTestDataInit() {
+LDTestDataInit(void) {
     struct LDTestData *res;
     struct LDJSON *currentFlags;
     if(!ALLOCATE(struct LDTestData, res)) {


### PR DESCRIPTION
Warnings raised by Clang 15.
A function declaration without a prototype is deprecated in all versions of C.  

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

