### PR TITLE
Fix: return NULL if the provided user key in test data is NULL

### DIFF
--- a/src/integrations/test_data.c
+++ b/src/integrations/test_data.c
@@ -587,6 +587,7 @@ LDi_buildTargetJSON(struct LDFlagBuilderTarget *target) {
 
     if(!(users = LDi_buildUsersJSON(target->users))) {
         LDJSONFree(res);
+        return NULL;
     }
 
     if(!LDObjectSetKey(res, "values", users)) {

--- a/tests/test-test-data.cpp
+++ b/tests/test-test-data.cpp
@@ -383,3 +383,9 @@ TEST_F(TestDataFixture, TestVariationForAllUsers) {
         ASSERT_EQ(LDBooleanTrue, result);
     }
 }
+
+TEST_F(TestDataFixture, TestFlagNULLUserKey) {
+    struct LDFlagBuilder *flag = LDTestDataFlag(td, "flag1");
+    LDFlagBuilderVariationForUser(flag, NULL, 1);
+    ASSERT_EQ(LDTestDataUpdate(td, flag), LDBooleanFalse);
+}

--- a/tests/test-test-data.cpp
+++ b/tests/test-test-data.cpp
@@ -388,4 +388,6 @@ TEST_F(TestDataFixture, TestFlagNULLUserKey) {
     struct LDFlagBuilder *flag = LDTestDataFlag(td, "flag1");
     LDFlagBuilderVariationForUser(flag, NULL, 1);
     ASSERT_EQ(LDTestDataUpdate(td, flag), LDBooleanFalse);
+    
+    LDFlagBuilderFree(flag);
 }


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

None

**Describe the solution you've provided**

LDi_buildUsersJSON stops execution and returns when LDi_buildUsersJSON fails, which can happen because of lack of memory or if the provided userKey was NULL

**Describe alternatives you've considered**

None

**Additional context**

Since this code is used only for testing, it does not provide any high risk apart from a crash/undefined behaviour during testing.
